### PR TITLE
Reapply: FOR_UPSTREAM: [VP] Fix static checker - Null pointer 'pPrvSu…

### DIFF
--- a/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp
+++ b/media_driver/agnostic/common/vp/hal/vphal_render_vebox_base.cpp
@@ -2247,6 +2247,7 @@ void VPHAL_VEBOX_STATE::VeboxSetCommonRenderingFlags(
     // Flags needs to be set if the reference sample is valid
     if (pRenderData->bRefValid)
     {
+        VPHAL_RENDER_CHK_NULL_NO_STATUS(pPrvSurf);
         pRenderData->bSameSamples   =
                WITHIN_BOUNDS(
                       pCurSurf->FrameID - pVeboxState->iCurFrameID,
@@ -2277,6 +2278,9 @@ void VPHAL_VEBOX_STATE::VeboxSetCommonRenderingFlags(
 
     // Cache Render Target pointer
     pRenderData->pRenderTarget = pRenderTarget;
+
+finish:
+    return;
 }
 
 //!


### PR DESCRIPTION
…rf' may be dereferenced

This path is removed during merge. Re-apply it for kw scan.

Change-Id: I267c707c6e457396cb6d0d8594805fb4fcd78248
Tracked-On: https://jira.devtools.intel.com/browse/OAM-86705
Signed-off-by: Badiuzzaman Iskhandar <badiuzzaman.azzarfan.bin.iskhandar@intel.com>
Reviewed-on: https://android.intel.com:443/669516
Reviewed-on: https://android.intel.com:443/680822