### PR TITLE
Link libgmm_umd via shared so mode.

### DIFF
--- a/Tools/MediaDriverTools/Android/mk/gmm.tpl
+++ b/Tools/MediaDriverTools/Android/mk/gmm.tpl
@@ -40,4 +40,4 @@ LOCAL_EXPORT_C_INCLUDE_DIRS = \
     $(LOCAL_PATH)/Source/inc \
     $(LOCAL_PATH)/Source/inc/common \
 
-include $(BUILD_STATIC_LIBRARY)
+include $(BUILD_SHARED_LIBRARY)

--- a/Tools/MediaDriverTools/Android/mk/media_driver.tpl
+++ b/Tools/MediaDriverTools/Android/mk/media_driver.tpl
@@ -34,9 +34,6 @@ LOCAL_SHARED_LIBRARIES := \
     libva \
     liblog \
     libpciaccess \
-
-
-LOCAL_STATIC_LIBRARIES = \
     libgmm_umd \
 
 LOCAL_CPPFLAGS = \

--- a/media_driver/Android.mk
+++ b/media_driver/Android.mk
@@ -719,9 +719,6 @@ LOCAL_SHARED_LIBRARIES := \
     libva \
     liblog \
     libpciaccess \
-
-
-LOCAL_STATIC_LIBRARIES = \
     libgmm_umd \
 
 LOCAL_CPPFLAGS = \


### PR DESCRIPTION
Changed the static link to libgmm_umd to shared mode.

Tracked-On: OAM-91697
Change-Id: I32b23059d9d2f5741e6b1f8ed8bdb786cbd6fe8d
Signed-off-by: Wan Shuang <shuang.wan@intel.com>