### PR TITLE
Disable scalability mode for HCP on TGL

### DIFF
--- a/media_driver/agnostic/gen12/codec/hal/codechal_decode_hevc_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_decode_hevc_g12.cpp
@@ -2284,6 +2284,11 @@ MOS_STATUS CodechalDecodeHevcG12::AllocateStandard (
 
     if ( MOS_VE_SUPPORTED(m_osInterface))
     {
+#ifdef ANDROID
+        // This is a w/a solution on Android as scalability is not working
+        // Remove it after we fix it.
+        static_cast<MhwVdboxMfxInterfaceG12*>(m_mfxInterface)->DisableScalabilitySupport();
+#endif
         if (static_cast<MhwVdboxMfxInterfaceG12*>(m_mfxInterface)->IsScalabilitySupported())
         {
             m_scalabilityState = (PCODECHAL_DECODE_SCALABILITY_STATE_G12)MOS_AllocAndZeroMemory(sizeof(CODECHAL_DECODE_SCALABILITY_STATE_G12));

--- a/media_driver/agnostic/gen12/codec/hal/codechal_decode_vp9_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_decode_vp9_g12.cpp
@@ -1256,6 +1256,11 @@ MOS_STATUS CodechalDecodeVp9G12 :: AllocateStandard (
 
    if ( MOS_VE_SUPPORTED(m_osInterface))
     {
+#ifdef ANDROID
+        // This is a w/a solution on Android as scalability is not working
+        // Remove it after we fix it
+        static_cast<MhwVdboxMfxInterfaceG12*>(m_mfxInterface)->DisableScalabilitySupport();
+#endif
         if (static_cast<MhwVdboxMfxInterfaceG12*>(m_mfxInterface)->IsScalabilitySupported())
         {
             m_scalabilityState = (PCODECHAL_DECODE_SCALABILITY_STATE_G12)MOS_AllocAndZeroMemory(sizeof(CODECHAL_DECODE_SCALABILITY_STATE_G12));


### PR DESCRIPTION
This is work around solution to temporally disable
scalability mode for hevc/vp9 decoder on TGL. Remove
this work around after we have scalability ready in
KMD on Android.

Tracked-On: OAM-95851
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>