### PR TITLE
Changes (mentioned below) for Codec2 enable & OneVPL integration with…

### DIFF
--- a/media_driver/Android.mk
+++ b/media_driver/Android.mk
@@ -919,7 +919,8 @@ LOCAL_CPPFLAGS := \
     -D__STDC_CONSTANT_MACROS \
     -D__STDC_LIMIT_MACROS \
     -D__VPHAL_SFC_SUPPORTED=1 \
-    -DiHD_drv_video_EXPORTS
+    -DiHD_drv_video_EXPORTS \
+    -Wno-pragma-pack-suspicious-include
 
 LOCAL_CONLYFLAGS = -x c++
 LOCAL_CFLAGS = $(LOCAL_CPPFLAGS)

--- a/media_driver/linux/common/cm/hal/cm_mem_os.cpp
+++ b/media_driver/linux/common/cm/hal/cm_mem_os.cpp
@@ -37,7 +37,12 @@ typedef void(*t_CmFastMemCopyFromWC)( void* dst, const void* src, const size_t b
 
 void CmFastMemCopyFromWC( void* dst, const void* src, const size_t bytes, CPU_INSTRUCTION_LEVEL cpuInstructionLevel )
 {
-    static const bool is_SSE4_available = (cpuInstructionLevel >= CPU_INSTRUCTION_LEVEL_SSE4_1);
+    //static const bool is_SSE4_available = (cpuInstructionLevel >= CPU_INSTRUCTION_LEVEL_SSE4_1);
+    bool is_SSE4_available = false;
+#if defined(__SSE4_1__)
+    is_SSE4_available = true;
+#endif
+
     static const t_CmFastMemCopyFromWC CmFastMemCopyFromWC_impl = CM_FAST_MEM_COPY_CPU_INIT(CmFastMemCopyFromWC);
 
     CmFastMemCopyFromWC_impl(dst, src, bytes);


### PR DESCRIPTION
Changes (mentioned below) for Codec2 enable & OneVPL integration with CiC-cloud

- Modified checks for SSE4.1 support to resolve build errors with Clang-11.
- Added "no-pragma-pack-suspicious-include" in LOCAL_CPPFLAGS to resolve build errors with Clang-11.

Tracked-On: OAM-100436
Signed-off-by: neeraj solanki <neeraj.solanki@intel.com>