### PR TITLE
Use Tile4 format for dGPU codec.

### DIFF
--- a/media_driver/linux/common/ddi/media_libva_util.cpp
+++ b/media_driver/linux/common/ddi/media_libva_util.cpp
@@ -471,10 +471,17 @@ VAStatus DdiMediaUtil_AllocateSurface(
         gmmCustomParams.BaseAlignment = 4096;
         gmmCustomParams.NoOfPlanes    = mediaSurface->pSurfDesc->uiPlanes;
         gmmCustomParams.CpTag         = cpTag;
+
+        int32_t deviceId = mediaDrvCtx->iDeviceId;
+
         switch (tileformat)
         {
             case I915_TILING_Y:
-                gmmCustomParams.Flags.Info.TiledY = true;
+		//DG2 pciid from kernel/include/drm/i915_pciids.h#696
+		if (deviceId >= 0x5690 && deviceId <= 0x56B3)
+                    gmmCustomParams.Flags.Info.Tile4 = true;
+		else
+                    gmmCustomParams.Flags.Info.TiledY = true;
                 gmmCustomParams.Flags.Gpu.MMC    = false;
                 if (MEDIA_IS_SKU(&mediaDrvCtx->SkuTable, FtrE2ECompression) &&
                     (!MEDIA_IS_WA(&mediaDrvCtx->WaTable, WaDisableVPMmc)    &&

--- a/media_softlet/linux/common/ddi/media_libva_util_next.cpp
+++ b/media_softlet/linux/common/ddi/media_libva_util_next.cpp
@@ -326,10 +326,17 @@ VAStatus MediaLibvaUtilNext::GenerateGmmParamsForNoneCompressionExternalSurface(
     gmmCustomParams.BaseAlignment = 4096;
     gmmCustomParams.NoOfPlanes    = mediaSurface->pSurfDesc->uiPlanes;
     gmmCustomParams.CpTag         = params.cpTag;
+
+    PDDI_MEDIA_CONTEXT mediaDrvCtx = mediaSurface->pMediaCtx;
+    int32_t deviceId = mediaDrvCtx->iDeviceId;
     switch (params.tileFormat)
     {
         case I915_TILING_Y:
-            gmmCustomParams.Flags.Info.TiledY = true;
+	    //DG2 pciid from kernel/include/drm/i915_pciids.h#696
+	    if (deviceId >= 0x5690 && deviceId <= 0x56B3)
+                gmmCustomParams.Flags.Info.Tile4 = true;
+	    else
+		gmmCustomParams.Flags.Info.TiledY = true;
             break;
         case I915_TILING_X:
             gmmCustomParams.Flags.Info.TiledX = true;


### PR DESCRIPTION
1/ Use TileY for iGPU codec
2/ Use Tile4 format for dGPU codec
3/ detect device is dGPU or iGPU dynamically according to deviceId. dGPU:  0x5690 <= deviceId <= 0x56B3

Tracked-On: OAM-112744