### PR TITLE
Fixed CTS issues

### DIFF
--- a/Tools/MediaDriverTools/UMDPerfProfiler/igfx_user_feature_next.txt
+++ b/Tools/MediaDriverTools/UMDPerfProfiler/igfx_user_feature_next.txt
@@ -4,5 +4,7 @@ Perf Profiler Output File Name=linux_perf_out.bin
 Perf Profiler Multi Process Support=0
 Perf Profiler Register 8=1835148
 Perf Profiler Buffer Size=10000000
+Enable HCP Scalability Decode=0
+Disable Media Encode Scalability=1
 
 [report]

--- a/media_softlet/linux/common/os/osservice/mos_utilities_specific.h
+++ b/media_softlet/linux/common/os/osservice/mos_utilities_specific.h
@@ -46,8 +46,9 @@ class MosMutex;
 #define USER_FEATURE_KEY_EXTERNAL            "UFKEY_EXTERNAL\\"
 
 //user feature
-#if ANDROID_VERSION >= 800
-#define USER_FEATURE_FILE                   "/data/igfx_user_feature.txt"
+#ifdef ANDROID
+#define USER_FEATURE_FILE                   "/vendor/etc/igfx_user_feature.txt"
+#define USER_FEATURE_FILE_NEXT              "/vendor/etc/igfx_user_feature_next.txt"
 #else
 #define USER_FEATURE_FILE                   "/etc/igfx_user_feature.txt"
 #define USER_FEATURE_FILE_NEXT              "/etc/igfx_user_feature_next.txt"


### PR DESCRIPTION
Scalability feature will cause gpu hang issue.
when run video cts of CtsMediaEncoderTestCases.

set the configs below in igfx_user_feature_next.txt Enable HCP Scalability Decode=0
Disable Media Encode Scalability=1
to disable Scalability feature.

Tracked-On: OAM-120515