### PR TITLE
[WA] Disable Scalability for VP9 encoding by default

### DIFF
--- a/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
+++ b/media_driver/agnostic/gen12/codec/hal/codechal_vdenc_vp9_g12.cpp
@@ -967,7 +967,7 @@ MOS_STATUS CodechalVdencVp9StateG12::GetSystemPipeNumberCommon()
         &userFeatureData,
         m_osInterface->pOsContext);
 
-    bool disableScalability = m_hwInterface->IsDisableScalability();
+    bool disableScalability = true; // m_hwInterface->IsDisableScalability();
     if (statusKey == MOS_STATUS_SUCCESS)
     {
         disableScalability = userFeatureData.i32Data ? true : false;


### PR DESCRIPTION
In VP9 8K encoding case, scalability is enabled. and make encoding incorrect. Issue is reported to upstream on https://github.com/intel/media-driver/issues/1847

Tracked-On: OAM-123073