### PR TITLE
Search for first Intel GPU rather than hard code renderD128

### DIFF
--- a/media_softlet/linux/common/os/i915_production/mos_bufmgr_prelim.cpp
+++ b/media_softlet/linux/common/os/i915_production/mos_bufmgr_prelim.cpp
@@ -88,8 +88,6 @@
     }                                  \
 }
 
-bool BufmgrPrelim::m_prelimEnabled = false;
-
 BufmgrPrelim *BufmgrPrelim::CreatePrelim(int fd)
 {
     if (fd < 0) {
@@ -110,17 +108,9 @@ BufmgrPrelim *BufmgrPrelim::CreatePrelim(int fd)
 
     if (0 == drmIoctl(fd, DRM_IOCTL_I915_QUERY, &q) && item.length > 0) {
         prelim = new BufmgrPrelim(fd);
-        if (nullptr != prelim) {
-            m_prelimEnabled = true;
-        }
     }
 
     return prelim;
-}
-
-bool BufmgrPrelim::IsPrelimSupported()
-{
-    return m_prelimEnabled;
 }
 
 void BufmgrPrelim::DestroyPrelim(BufmgrPrelim *prelim)

--- a/media_softlet/linux/common/os/i915_production/mos_bufmgr_prelim.h
+++ b/media_softlet/linux/common/os/i915_production/mos_bufmgr_prelim.h
@@ -104,7 +104,6 @@ private:
 private:
     uint32_t m_tileId = 0;
     int m_fd = -1;
-    static bool m_prelimEnabled;
 
     static constexpr uint32_t TYPE_DECIMAL = 10;
 


### PR DESCRIPTION
Previously we assume that renderD128 is the device we want, which breaks when scenarios become complicated. Instead, search for Intel GPUs and use the first one (being iGPU if present).

Tracked-On: OAM-124779